### PR TITLE
Add ResNet-based feature extractor

### DIFF
--- a/multi_camera/feature_extractor.py
+++ b/multi_camera/feature_extractor.py
@@ -5,25 +5,77 @@ from typing import Optional
 
 import numpy as np
 
+import torch
+from torchvision import models, transforms
+
 
 class FeatureExtractor:
     """Wrapper around a person re-identification model."""
 
     def __init__(self, model_path: Optional[str] = None) -> None:
-        """Initialize and load the underlying model."""
-        self.model_path = model_path
-        # Placeholder for model loading
-        self.model = None
+        """Initialize and load the underlying model.
+
+        Parameters
+        ----------
+        model_path:
+            Optional path to a model checkpoint containing weights for the
+            512‑dimensional embedding layer.  If omitted the embedding layer
+            remains randomly initialised which is sufficient for testing
+            purposes.
+        """
+
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        # Load an ImageNet pre‑trained ResNet‑50 backbone and replace the final
+        # classification layer with a 512‑D embedding layer.
+        self.model = models.resnet50(weights=models.ResNet50_Weights.IMAGENET1K_V2)
+        in_features = self.model.fc.in_features
+        self.model.fc = torch.nn.Linear(in_features, 512)
+
+        if model_path is not None:
+            state_dict = torch.load(model_path, map_location=self.device)
+            self.model.load_state_dict(state_dict)
+
+        self.model.to(self.device)
+        self.model.eval()
+
+        # Standard ImageNet preprocessing pipeline.
+        self._preprocess = transforms.Compose(
+            [
+                transforms.ToPILImage(),
+                transforms.Resize((224, 224)),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406],
+                    std=[0.229, 0.224, 0.225],
+                ),
+            ]
+        )
 
     # ------------------------------------------------------------------
     def extract(self, cropped: np.ndarray) -> np.ndarray:
         """Generate a feature vector for the provided image.
 
-        Args:
-            cropped: Image array containing the detected object.
+        The image is preprocessed, passed through the ResNet‑50 backbone and
+        normalised to unit length.
 
-        Returns:
-            A 1D feature vector uniquely describing the object.
+        Parameters
+        ----------
+        cropped:
+            Image array containing the detected object (H x W x C in RGB).
+
+        Returns
+        -------
+        np.ndarray
+            Normalised 512‑D embedding representing the object.
         """
-        # Placeholder: random vector representing feature signature
-        return np.random.rand(512)
+
+        # Convert to tensor and move to the appropriate device
+        tensor = self._preprocess(cropped).unsqueeze(0).to(self.device)
+
+        with torch.no_grad():
+            features = self.model(tensor)
+
+        # L2 normalise to obtain the final descriptor
+        features = torch.nn.functional.normalize(features, p=2, dim=1)
+        return features.squeeze(0).cpu().numpy()


### PR DESCRIPTION
## Summary
- load a pretrained ResNet-50 backbone and create a 512-D embedding layer
- preprocess crops, run the model, and return normalized 512-D descriptors

## Testing
- `python -m py_compile multi_camera/feature_extractor.py`
- `python - <<'PY'
from multi_camera.feature_extractor import FeatureExtractor
import numpy as np

fe = FeatureExtractor()
print('model loaded')
img = np.zeros((224,224,3), dtype=np.uint8)
vec = fe.extract(img)
print(vec.shape)
PY` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install 'torch==2.0.1+cpu' 'torchvision==0.15.2+cpu' --extra-index-url https://download.pytorch.org/whl/cpu -q` *(fails: Could not find a version that satisfies the requirement torch==2.0.1+cpu)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0e8212808333a653a6b789c059d8